### PR TITLE
Add RecordNotFoundException

### DIFF
--- a/lib/flutter_rest_data.dart
+++ b/lib/flutter_rest_data.dart
@@ -3,3 +3,4 @@ library flutter_rest_data;
 export 'package:rest_data/rest_data.dart';
 
 export 'src/adapters/persistent_json_api.dart';
+export 'src/exceptions.dart';

--- a/lib/src/adapters/persistent_json_api.dart
+++ b/lib/src/adapters/persistent_json_api.dart
@@ -125,7 +125,11 @@ class PersistentJsonApiAdapter extends JsonApiAdapter {
 
   Future<JsonApiDocument> boxGetOne(String endpoint, String id) async {
     var box = await openBox(endpoint);
-    return box.get(id);
+    var doc = box.get(id);
+    if (doc == null) {
+      throw RecordNotFoundException();
+    }
+    return doc;
   }
 
   Future<JsonApiManyDocument> boxGetMany(

--- a/lib/src/adapters/persistent_json_api.dart
+++ b/lib/src/adapters/persistent_json_api.dart
@@ -2,6 +2,7 @@ import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:rest_data/rest_data.dart';
 
+import '../exceptions.dart';
 import '../hive_adapters/json_api.dart';
 
 typedef FilterFunction = bool Function(JsonApiDocument);
@@ -132,7 +133,11 @@ class PersistentJsonApiAdapter extends JsonApiAdapter {
     Iterable<String> ids,
   ) async {
     var box = await openBox(endpoint);
-    var docs = ids.map((id) => box.get(id)).toList();
+    var docs =
+        ids.map((id) => box.get(id)).where((doc) => doc != null).toList();
+    if (ids.isNotEmpty && docs.isEmpty) {
+      throw RecordNotFoundException();
+    }
     return JsonApiManyDocument(docs);
   }
 

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,1 @@
+class RecordNotFoundException implements Exception {}


### PR DESCRIPTION
When records are requested by ID, and they're not found on the local Hive files, then a `RecordNotFoundException` is thrown.